### PR TITLE
Fix Visitor Data Producing Invalid Tokens Due to URL Decoding

### DIFF
--- a/potoken_generator/extractor.py
+++ b/potoken_generator/extractor.py
@@ -3,6 +3,7 @@ import dataclasses
 import json
 import logging
 import time
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
@@ -75,6 +76,7 @@ class PotokenExtractor:
         try:
             post_data_json = json.loads(post_data)
             visitor_data = post_data_json['context']['client']['visitorData']
+            visitor_data = urllib.parse.unquote(visitor_data).rstrip('=')
             potoken = post_data_json['serviceIntegrityDimensions']['poToken']
         except (json.JSONDecodeError, TypeError, KeyError) as e:
             logger.warning(f'failed to extract token from request: {type(e)}, {e}')


### PR DESCRIPTION
During the process of grabbing the authentication tokens from YouTube's API, there is an issue where the `Visitor Data` token is returned with URL encoded padding characters (**%3D**) which is the ASCII representation of the equals character (**=**).

The fix is decoding the URL through python's standard library; `urllib`, we use it's `.parse.unquote()` function and then strip the characters from the end using `rstrip('=')`.