### PR TITLE
Added environment variables to control bind address

### DIFF
--- a/docker/scripts/startup-webserver.sh
+++ b/docker/scripts/startup-webserver.sh
@@ -10,13 +10,8 @@ sleep 2
 
 echo "[INFO] launching chromium instance"
 
-if [ -z $HOST ]; then
-	export HOST=0.0.0.0
-fi
-
-if [ -z $PORT ]; then
-	export PORT=8080
-fi
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-8080}
 
 # Run python script on display 0
 DISPLAY=:99 python potoken-generator.py --bind $HOST --port $PORT

--- a/docker/scripts/startup-webserver.sh
+++ b/docker/scripts/startup-webserver.sh
@@ -11,13 +11,11 @@ sleep 2
 echo "[INFO] launching chromium instance"
 
 if [ -z $HOST ]; then
-	echo "[ERROR] Missing environment variable \$HOST."
-	exit 1
+	export HOST=0.0.0.0
 fi
 
 if [ -z $PORT ]; then
-	echo "[ERROR] Missing environment variable \$PORT."
-	exit 1
+	export PORT=8080
 fi
 
 # Run python script on display 0

--- a/docker/scripts/startup-webserver.sh
+++ b/docker/scripts/startup-webserver.sh
@@ -10,5 +10,15 @@ sleep 2
 
 echo "[INFO] launching chromium instance"
 
+if [ -z $HOST ]; then
+	echo "[ERROR] Missing environment variable \$HOST."
+	exit 1
+fi
+
+if [ -z $PORT ]; then
+	echo "[ERROR] Missing environment variable \$PORT."
+	exit 1
+fi
+
 # Run python script on display 0
-DISPLAY=:99 python potoken-generator.py --bind 0.0.0.0
+DISPLAY=:99 python potoken-generator.py --bind $HOST --port $PORT

--- a/docker/scripts/startup-webserver.sh
+++ b/docker/scripts/startup-webserver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "[INFO] internally launching GUI (X11 environment)"
 

--- a/docker/scripts/startup.sh
+++ b/docker/scripts/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "[INFO] internally launching GUI (X11 environment)"
 


### PR DESCRIPTION
Fulfilling wishes of #19.

This PR should allow to set the host and port of the webserver like so:
```
docker run -e HOST=127.0.0.1 -e PORT=80 quay.io/invidious/youtube-trusted-session-generator:webserver
```

I can't test it in docker due to unfamiliarity with it but I know my shell scripting. hope this helps.