### PR TITLE
Allow headless applications via os.environ

### DIFF
--- a/potoken_generator/extractor.py
+++ b/potoken_generator/extractor.py
@@ -3,6 +3,7 @@ import dataclasses
 import json
 import logging
 import time
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
@@ -100,8 +101,9 @@ class PotokenExtractor:
         async with self._ongoing_update:
             logger.info('update started')
             self._extraction_done.clear()
+            headless = os.environ.get("POTOKEN_HEADLESS", "0") == "1
             try:
-                browser = await nodriver.start(headless=False,
+                browser = await nodriver.start(headless=headless,
                                                browser_executable_path=self.browser_path,
                                                user_data_dir=self.profile_path)
             except FileNotFoundError as e:


### PR DESCRIPTION
Arguable, this app should be headless should be the default. However, an env var does the trick.